### PR TITLE
Add lengths calculations

### DIFF
--- a/src/bits/lengths.ts
+++ b/src/bits/lengths.ts
@@ -1,0 +1,31 @@
+import { fromBcd, toBcd } from '@internals/bcd'
+import { ERR } from '@internals/constants'
+import { LenHeaderEncoding } from '../formats'
+
+type MaxDigits = 2 | 3
+type HeaderLenInfo = { len: number; read: number }
+
+export const writeLenHeader = (len: number, digits: MaxDigits, enc: LenHeaderEncoding): Buffer => {
+  const s = String(len).padStart(digits, '0')
+  return enc === 'ascii' ? Buffer.from(s, 'ascii') : toBcd(s)
+}
+
+export const readLenHeader = (
+  buf: Buffer,
+  offset: number,
+  digits: MaxDigits,
+  enc: LenHeaderEncoding,
+): HeaderLenInfo => {
+  if (enc === 'ascii') {
+    const slice = buf.subarray(offset, offset + digits)
+    if (slice.length < digits) throw new Error(ERR.LEN_HDR_UNDERRUN)
+    const n = Number(slice.toString('ascii'))
+    if (Number.isNaN(n)) throw new Error(ERR.INVALID_ASCII_LEN)
+    return { len: n, read: digits }
+  }
+  const bytes = Math.ceil(digits / 2)
+  const slice = buf.subarray(offset, offset + bytes)
+  if (slice.length < bytes) throw new Error(ERR.LEN_HDR_UNDERRUN)
+  const s = fromBcd(slice, digits)
+  return { len: Number(s), read: bytes }
+}

--- a/src/formats.ts
+++ b/src/formats.ts
@@ -1,1 +1,2 @@
 export type NumericEncoding = 'bcd' | 'ascii'
+export type LenHeaderEncoding = 'bcd' | 'ascii'

--- a/src/internals/bcd.ts
+++ b/src/internals/bcd.ts
@@ -1,11 +1,18 @@
 import { digitsOnly } from '@internals/digits'
+import { ERR } from './constants'
 
 export const fromBcd = (buf: Buffer, digits: number): string => {
   let s = ''
   for (let i = 0; i < buf.length; i++) {
-    const b = buf[i]
-    s += String((b >> 4) & 0x0f)
-    s += String(b & 0x0f)
+    const hi = (buf[i] >> 4) & 0x0f
+    const lo = buf[i] & 0x0f
+
+    if (hi > 9 || lo > 9) {
+      throw new Error(ERR.INVALID_BCD_DIGIT(buf[i]))
+    }
+
+    s += hi.toString()
+    s += lo.toString()
   }
   return s.slice(s.length - digits)
 }

--- a/src/internals/constants.ts
+++ b/src/internals/constants.ts
@@ -6,7 +6,10 @@ export const ERR = {
   BITMAP_SIZE: 'Bitmap must be 8 or 16 bytes',
   DE_RANGE: 'DE must be 2..128',
   EXPECT_DIGITS: (s: string) => `Expected digits only, got "${s}"`,
+  INVALID_ASCII_LEN: 'Invalid ASCII length header',
+  INVALID_BCD_DIGIT: (b: number) => `Invalid BCD digit: 0x${b.toString(16).padStart(2, '0')}`,
   INVALID_MTI: (m: string) => `Invalid MTI "${m}" (expect 4 digits)`,
+  LEN_HDR_UNDERRUN: 'Length header underrun',
   SEC_BITMAP_CONSTRAINED: 'Secondary bitmap present but constrained to 64',
 }
 

--- a/tests/bits/lengths.test.ts
+++ b/tests/bits/lengths.test.ts
@@ -1,0 +1,72 @@
+import { readLenHeader, writeLenHeader } from '@bits/lengths'
+import { fromBcd, toBcd } from '@internals/bcd'
+import { toAsciiBuffer, toHex, toHexBuffer } from '../utils'
+
+vi.mock('@internals/bcd', () => ({
+  fromBcd: vi.fn(),
+  toBcd: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('lengths', () => {
+  describe('writeLenHeader', () => {
+    const toBcdMocked = vi.mocked(toBcd)
+    describe('ascii encoding', () => {
+      it('returns 0 padded ascii buffer when input is single digit, max digits is 2 and encoding is ascii', () => {
+        const ret = writeLenHeader(1, 2, 'ascii')
+        expect(ret).toEqual(toAsciiBuffer('01'))
+        expect(toBcdMocked).not.toHaveBeenCalled()
+      })
+
+      it('returns 00 padded ascii buffer when input is single digit, max digits is 3 and encoding is ascii', () => {
+        const ret = writeLenHeader(1, 3, 'ascii')
+        expect(ret).toEqual(toAsciiBuffer('001'))
+        expect(toBcdMocked).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('bcd encoding', () => {
+      it('returns BCD encoded buffer when encoding is bcd', () => {
+        toBcdMocked.mockReturnValue(toHexBuffer('01'))
+        const ret = writeLenHeader(1, 2, 'bcd')
+        expect(toHex(ret)).toEqual('01')
+        expect(toBcdMocked).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('readLenHeader', () => {
+    const fromBcdMocked = vi.mocked(fromBcd)
+    describe('ascii encoding', () => {
+      it('throws if the sliced length is less than expected length', () => {
+        expect(() => readLenHeader(toAsciiBuffer('1'), 0, 2, 'ascii')).toThrow(/Length header underrun/)
+      })
+
+      it('throws if length is not a number', () => {
+        expect(() => readLenHeader(toAsciiBuffer('A1BCD'), 0, 2, 'ascii')).toThrow(/Invalid ASCII length header/)
+        expect(fromBcdMocked).not.toHaveBeenCalled()
+      })
+
+      it('returns correct length and the number of digits read', () => {
+        const resp = readLenHeader(toAsciiBuffer('02ABCDEF'), 0, 2, 'ascii')
+        expect(resp).to.deep.equal({ len: 2, read: 2 })
+        expect(fromBcdMocked).not.toHaveBeenCalled()
+      })
+    })
+    describe('bcd encoding', () => {
+      it('throws if the sliced length is less than expected length', () => {
+        expect(() => readLenHeader(toHexBuffer('1'), 0, 2, 'bcd')).toThrow(/Length header underrun/)
+      })
+
+      it('returns correct length and the number of digits read', () => {
+        fromBcdMocked.mockReturnValue('02')
+        const resp = readLenHeader(toHexBuffer('02ABCDEF'), 0, 2, 'bcd')
+        expect(resp).to.deep.equal({ len: 2, read: 1 })
+        expect(fromBcdMocked).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/tests/internals/bcd.test.ts
+++ b/tests/internals/bcd.test.ts
@@ -39,6 +39,10 @@ describe('bcd', () => {
   })
 
   describe('fromBcd', () => {
+    it('throws if buffer contains non numeric characters', () => {
+      expect(() => fromBcd(toHexBuffer('ABCDEFGH'), 4)).toThrow(/Invalid BCD digit/)
+    })
+
     it('decodes when digits equals total length', () => {
       expect(fromBcd(toHexBuffer('1234567890'), 10)).toBe('1234567890')
     })


### PR DESCRIPTION
- Added lengths calculations and tests
- Updated fromBCD to throw if the passed in Buffer is invalid (such as if they are not numeric)