### PR TITLE
Added main Iso8583 class and helper methods. Marked internal methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "iso8583-ts",
-  "type": "module",
   "version": "0.0.1",
   "description": "ISO 8583 parser written in TypeScript with LLVAR/LLLVAR enforcement and bitmap handling.",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/iso8583.js",
+  "types": "dist/iso8583.d.ts",
   "files": [
     "dist/**/*"
   ],

--- a/src/encodings/alpha.ts
+++ b/src/encodings/alpha.ts
@@ -5,12 +5,14 @@ import { AFormat, ANFormat, ANSFormat } from '@internals/formats'
 type AlphaFormat = AFormat | ANFormat | ANSFormat
 type DecodeAlpha = { value: string; read: number }
 
+/** @internal */
 export const encodeAlpha = (de: number, f: AlphaFormat, value: string): Buffer => {
   if (value.length > f.length) throw new Error(ERR.FIELD_EXCEEDS(de, f.kind, f.length))
   validateAlpha(f.kind, value)
   return Buffer.from(value.padEnd(f.length, ' '), 'ascii')
 }
 
+/** @internal */
 export const decodeAlpha = (f: AlphaFormat, buf: Buffer, offset: number): DecodeAlpha => {
   const slice = buf.subarray(offset, offset + f.length)
   const s = slice.toString('ascii').trimEnd()

--- a/src/encodings/binary.ts
+++ b/src/encodings/binary.ts
@@ -3,6 +3,7 @@ import { BFormat } from '@internals/formats'
 
 type DecodeBinary = { value: Buffer; read: number }
 
+/** @internal */
 export const encodeBinary = (de: number, f: BFormat, value: Buffer | string): Buffer => {
   const expected = f.length
   let payload: Buffer | string
@@ -17,6 +18,7 @@ export const encodeBinary = (de: number, f: BFormat, value: Buffer | string): Bu
   return payload
 }
 
+/** @internal */
 export const decodeBinary = (de: number, f: BFormat, buf: Buffer, offset: number): DecodeBinary => {
   const slice = buf.subarray(offset, offset + f.length)
   if (slice.length < f.length) throw new Error(ERR.FIELD_UNDERRUN(de))

--- a/src/encodings/numeric.ts
+++ b/src/encodings/numeric.ts
@@ -4,6 +4,7 @@ import { NFormat, NumericEncoding } from '@internals/formats'
 
 type NumericReturn = { value: string; read: number }
 
+/** @internal */
 export const encodeNumeric = (f: NFormat, value: string | number): Buffer => {
   const enc = f.encoding ?? NumericEncoding.BCD
   let s = digitsOnly(String(value)).padStart(f.length, '0')
@@ -12,6 +13,7 @@ export const encodeNumeric = (f: NFormat, value: string | number): Buffer => {
   return toBcd(s)
 }
 
+/** @internal */
 export const decodeNumeric = (f: NFormat, buf: Buffer, offset: number): NumericReturn => {
   const enc = f.encoding ?? NumericEncoding.BCD
   if (enc === NumericEncoding.ASCII) {

--- a/src/encodings/varlen.ts
+++ b/src/encodings/varlen.ts
@@ -3,8 +3,9 @@ import { ERR } from '@internals/constants'
 import { LLLVARFormat, LLVARFormat, VarLenCountMode, VarPayloadEncoding } from '@internals/formats'
 import { applyVarDefaults, buildPayload, readLenHeader, writeLenHeader } from '@internals/varlen'
 
-type DecodeVar = { value: unknown; read: number }
+type DecodeVar = { value: Buffer | string; read: number }
 
+/** @internal */
 export const encodeVar = (de: number, f: LLVARFormat | LLLVARFormat, value: Buffer | string): Buffer => {
   const {
     payload: payloadEnc,
@@ -25,6 +26,7 @@ export const encodeVar = (de: number, f: LLVARFormat | LLLVARFormat, value: Buff
   return Buffer.concat([header, payload])
 }
 
+/** @internal */
 export const decodeVar = (de: number, f: LLVARFormat | LLLVARFormat, buf: Buffer, offset: number): DecodeVar => {
   const headerDigits = f.kind.startsWith('LLL') ? 3 : 2
   const { payload: payloadEnc, lenHeader: headerEnc, lenCountMode } = applyVarDefaults(de, f)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,24 @@
+export { Iso8583 } from './iso8583'
+export type { FieldSpec, MessageSpec } from './iso8583'
+
+export {
+  A,
+  AN,
+  ANS,
+  B,
+  bitmap,
+  Kind,
+  LLLVAR,
+  LLLVARan,
+  LLLVARans,
+  LLLVARn,
+  LLVAR,
+  LLVARan,
+  LLVARans,
+  LLVARn,
+  N,
+  NumericEncoding,
+  VarLenCountMode,
+  VarLenHeaderEncoding,
+  VarPayloadEncoding,
+} from './internals/formats'

--- a/src/internals/alpha.ts
+++ b/src/internals/alpha.ts
@@ -1,6 +1,7 @@
 import { ERR, RE } from './constants'
 import { Kind } from './formats'
 
+/** @internal */
 export const validateAlpha = (fmt: Kind.Alpha | Kind.AlphaNumeric | Kind.AlphaNumericSpecial, s: string): void => {
   const valid =
     (fmt === 'a' && RE.ALPHA.test(s)) || (fmt === 'an' && RE.ALNUM.test(s)) || (fmt === 'ans' && RE.PRINT.test(s))

--- a/src/internals/ascii.ts
+++ b/src/internals/ascii.ts
@@ -1,5 +1,6 @@
 import { ERR } from '@internals/constants'
 
+/** @internal */
 export const readAscii = (buf: Buffer, offset: number, len: number): string => {
   const slice = buf.subarray(offset, offset + len)
   if (slice.length < len) throw new Error(ERR.ASCII_UNDERRUN)

--- a/src/internals/bcd.ts
+++ b/src/internals/bcd.ts
@@ -1,6 +1,7 @@
 import { digitsOnly } from '@internals/digits'
 import { ERR } from './constants'
 
+/** @internal */
 export const fromBcd = (buf: Buffer, digits: number): string => {
   let s = ''
   for (let i = 0; i < buf.length; i++) {
@@ -17,6 +18,7 @@ export const fromBcd = (buf: Buffer, digits: number): string => {
   return s.slice(s.length - digits)
 }
 
+/** @internal */
 export const toBcd = (digits: string): Buffer => {
   const s = digitsOnly(digits)
   const padded = s.length % 2 ? '0' + s : s

--- a/src/internals/constants.ts
+++ b/src/internals/constants.ts
@@ -1,11 +1,14 @@
 import { Kind } from './formats'
 
+/** @internal */
 export type BitmapConstraint = 64 | 128
 
+/** @internal */
 export const ERR = {
   ASCII_UNDERRUN: 'ASCII underrun',
   BITMAP_64_CONSTRAINT: 'Bitmap constrained to 64 bits but DE>64 present',
   BITMAP_SIZE: 'Bitmap must be 8 or 16 bytes',
+  BITMAP_HELPER_SIZE: 'bitmap(): length must be 8 or 16 bytes',
   DE_RANGE: 'DE must be 2..128',
   EXPECT_DIGITS: (s: string) => `Expected digits only, got "${s}"`,
   FIELD_BYTES: (de: number, expected: number) => `DE${de} must be ${expected} bytes`,
@@ -17,12 +20,21 @@ export const ERR = {
     `Value not valid for "${fmt}" field`,
   INVALID_ASCII_LEN: 'Invalid ASCII length header',
   INVALID_BCD_DIGIT: (b: number) => `Invalid BCD digit: 0x${b.toString(16).padStart(2, '0')}`,
+  INVALID_BITMAP_SPEC: (de: number) => `Invalid bitmap field DE${de} spec (expect format: bitmap(8 or 16))`,
   INVALID_MTI: (m: string) => `Invalid MTI "${m}" (expect 4 digits)`,
+  INVALID_MTI_SPEC: (de: number) => `Invalid MTI field DE${de} spec (expect 4 digits, numeric)`,
   INVALID_VAR_DIGITS_FOR_NON_N: (de: number) => `DE${de} invalid lenCountMode=digits for non-n field`,
   LEN_HDR_UNDERRUN: 'Length header underrun',
+  KIND_HELPER_LEN_MUST_BE: (helper: string, operator: string, value: number) =>
+    `${helper}(): length must be ${operator} ${value}`,
+  NO_SPEC: (de: number) => `No spec for DE${de}`,
+  PRIMARY_UNDERRUN: 'Primary bitmap underrun',
   SEC_BITMAP_CONSTRAINED: 'Secondary bitmap present but constrained to 64',
+  SEC_UNDERRUN: 'Secondary bitmap underrun',
+  UNSUPPORTED: (k: string) => `Unsupported format ${k}`,
 }
 
+/** @internal */
 export const RE = {
   ALPHA: /^[A-Za-z]*$/,
   ALNUM: /^[A-Za-z0-9]*$/,

--- a/src/internals/digits.ts
+++ b/src/internals/digits.ts
@@ -1,5 +1,6 @@
 import { ERR } from '@internals/constants'
 
+/** @internal */
 export const digitsOnly = (s: string): string => {
   if (!/^\d*$/.test(s)) throw new Error(ERR.EXPECT_DIGITS(s))
   return s

--- a/src/internals/formats.ts
+++ b/src/internals/formats.ts
@@ -1,3 +1,6 @@
+import { ERR } from './constants'
+import { validateLLLVar, validateLLVar } from './varlen'
+
 export enum NumericEncoding {
   ASCII = 'ascii',
   BCD = 'bcd',
@@ -21,6 +24,7 @@ export enum Kind {
   AlphaNumeric = 'an',
   AlphaNumericSpecial = 'ans',
   Binary = 'b',
+  Bitmap = 'bitmap',
   LLVAR = 'LLVAR',
   LLVARn = 'LLVARn',
   LLVARan = 'LLVARan',
@@ -37,8 +41,19 @@ export type ANFormat = { kind: Kind.AlphaNumeric; length: number }
 export type ANSFormat = { kind: Kind.AlphaNumericSpecial; length: number }
 export type BFormat = { kind: Kind.Binary; length: number }
 export type NFormat = { kind: Kind.Numeric; length: number; encoding?: NumericEncoding }
+export type BitmapFormat = { kind: Kind.Bitmap; length: 8 | 16 }
 
-type VarBase = {
+export type FormatObject =
+  | NFormat
+  | AFormat
+  | ANFormat
+  | ANSFormat
+  | BFormat
+  | BitmapFormat
+  | LLVARFormat
+  | LLLVARFormat
+
+export type VarBase = {
   length: number
   payload?: VarPayloadEncoding
   lenHeader?: VarLenHeaderEncoding
@@ -51,3 +66,49 @@ export type LLLVARFormat = { kind: Kind.LLLVAR | Kind.LLLVARn | Kind.LLLVARan | 
 
 export type VARFormatRequired = (LLVARFormat | LLLVARFormat) &
   Required<Pick<VarBase, 'payload' | 'lenHeader' | 'lenCountMode'>>
+
+export const N = (length: number, opts?: { encoding?: NumericEncoding }): NFormat => {
+  if (length <= 0) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE('N', '>', 0))
+  return { kind: Kind.Numeric, length, encoding: opts?.encoding }
+}
+
+export const A = (length: number): AFormat => {
+  if (length <= 0) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE('A', '>', 0))
+  return { kind: Kind.Alpha, length }
+}
+
+export const AN = (length: number): ANFormat => {
+  if (length <= 0) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE('AN', '>', 0))
+  return { kind: Kind.AlphaNumeric, length }
+}
+
+export const ANS = (length: number): ANSFormat => {
+  if (length <= 0) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE('ANS', '>', 0))
+  return { kind: Kind.AlphaNumericSpecial, length }
+}
+
+export const B = (lengthBytes: number): BFormat => {
+  if (lengthBytes <= 0) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE('B', '>', 0))
+  return { kind: Kind.Binary, length: lengthBytes }
+}
+
+export const bitmap = (lengthBytes: 8 | 16): BitmapFormat => {
+  if (lengthBytes !== 8 && lengthBytes !== 16) throw new Error(ERR.BITMAP_HELPER_SIZE)
+  return { kind: Kind.Bitmap, length: lengthBytes }
+}
+
+export const LLVAR = (opts: VarBase): LLVARFormat => validateLLVar(Kind.LLVAR, opts)
+
+export const LLVARn = (opts: VarBase): LLVARFormat => validateLLVar(Kind.LLVARn, opts)
+
+export const LLVARan = (opts: VarBase): LLVARFormat => validateLLVar(Kind.LLVARan, opts)
+
+export const LLVARans = (opts: VarBase): LLVARFormat => validateLLVar(Kind.LLVARans, opts)
+
+export const LLLVAR = (opts: VarBase): LLLVARFormat => validateLLLVar(Kind.LLLVAR, opts)
+
+export const LLLVARn = (opts: VarBase): LLLVARFormat => validateLLLVar(Kind.LLLVARn, opts)
+
+export const LLLVARan = (opts: VarBase): LLLVARFormat => validateLLLVar(Kind.LLLVARan, opts)
+
+export const LLLVARans = (opts: VarBase): LLLVARFormat => validateLLLVar(Kind.LLLVARans, opts)

--- a/src/internals/varlen.ts
+++ b/src/internals/varlen.ts
@@ -4,6 +4,7 @@ import {
   Kind,
   LLLVARFormat,
   LLVARFormat,
+  VarBase,
   VARFormatRequired,
   VarLenCountMode,
   VarLenHeaderEncoding,
@@ -13,6 +14,7 @@ import {
 type MaxDigits = 2 | 3
 type HeaderLenInfo = { len: number; read: number }
 
+/** @internal */
 export const applyVarDefaults = (de: number, f: LLVARFormat | LLLVARFormat): VARFormatRequired => {
   const kind = f.kind
   const isNumericVar = [Kind.LLVARn, Kind.LLLVARn].includes(kind)
@@ -31,6 +33,7 @@ export const applyVarDefaults = (de: number, f: LLVARFormat | LLLVARFormat): VAR
   }
 }
 
+/** @internal */
 export const buildPayload = (enc: VarPayloadEncoding, value: Buffer | string) => {
   if (enc === VarPayloadEncoding.ASCII) {
     const s = String(value)
@@ -46,11 +49,13 @@ export const buildPayload = (enc: VarPayloadEncoding, value: Buffer | string) =>
   return { payload, byteLen: payload.length, digitLen: digits.length }
 }
 
+/** @internal */
 export const writeLenHeader = (len: number, digits: MaxDigits, enc: VarLenHeaderEncoding): Buffer => {
   const s = String(len).padStart(digits, '0')
   return enc === VarLenHeaderEncoding.ASCII ? Buffer.from(s, 'ascii') : toBcd(s)
 }
 
+/** @internal */
 export const readLenHeader = (
   buf: Buffer,
   offset: number,
@@ -69,4 +74,16 @@ export const readLenHeader = (
   if (slice.length < bytes) throw new Error(ERR.LEN_HDR_UNDERRUN)
   const s = fromBcd(slice, digits)
   return { len: Number(s), read: bytes }
+}
+
+export const validateLLVar = (kind: LLVARFormat['kind'], base: VarBase): LLVARFormat => {
+  if (base.length <= 0) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE(kind, '>', 0))
+  if (base.length > 99) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE(kind, '<=', 99))
+  return { kind, ...base }
+}
+
+export const validateLLLVar = (kind: LLLVARFormat['kind'], base: VarBase): LLLVARFormat => {
+  if (base.length <= 0) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE(kind, '>', 0))
+  if (base.length > 999) throw new Error(ERR.KIND_HELPER_LEN_MUST_BE(kind, '<=', 999))
+  return { kind, ...base }
 }

--- a/src/iso8583.ts
+++ b/src/iso8583.ts
@@ -1,0 +1,153 @@
+import { buildBitmap, parseBitmap } from '@bits/bitmap'
+import { assertMTI, decodeMTI, encodeMTI } from '@bits/mti'
+import { decodeAlpha, encodeAlpha } from '@encodings/alpha'
+import { decodeBinary, encodeBinary } from '@encodings/binary'
+import { decodeNumeric, encodeNumeric } from '@encodings/numeric'
+import { decodeVar, encodeVar } from '@encodings/varlen'
+import { BitmapConstraint, ERR } from '@internals/constants'
+import { FormatObject, Kind, NumericEncoding } from '@internals/formats'
+
+export type EncoderOptions = {
+  mtiEncoding?: NumericEncoding
+}
+
+export type FieldSpec = { name: string; format: FormatObject }
+export type MessageSpec = Record<number, FieldSpec>
+
+export type PackedMessage = { mti: string; bytes: Buffer }
+export type UnpackedMessage = { mti: string; fields: Record<number, Buffer | string | number>; bytesRead: number }
+
+export class Iso8583 {
+  private spec: MessageSpec
+  private mtiEncoding: NumericEncoding = NumericEncoding.BCD
+  private bitmapConstraint: BitmapConstraint = 64
+
+  constructor(spec: MessageSpec) {
+    this.spec = spec
+
+    const mtiField = this.spec[0]
+    if (mtiField) {
+      if (mtiField.format.kind !== Kind.Numeric) throw new Error(ERR.INVALID_MTI_SPEC(0))
+      this.mtiEncoding = mtiField.format.encoding || NumericEncoding.BCD
+    }
+
+    const bmField = this.spec[1]
+    if (bmField) {
+      if (bmField.format.kind !== Kind.Bitmap) throw new Error(ERR.INVALID_BITMAP_SPEC(1))
+      this.bitmapConstraint = bmField.format.length === 8 ? 64 : 128
+    }
+  }
+
+  pack = (mti: string, fields: Record<number, Buffer | string | number>): PackedMessage => {
+    assertMTI(mti)
+    const present = Object.keys(fields)
+      .map(Number)
+      .filter(n => n >= 2 && n <= 128)
+      .sort((a, b) => a - b)
+    for (const de of present) if (!this.spec[de]) throw new Error(ERR.NO_SPEC(de))
+
+    const chunks: Buffer[] = []
+    chunks.push(encodeMTI(mti, this.mtiEncoding))
+    chunks.push(buildBitmap(present, this.bitmapConstraint))
+
+    for (const de of present) {
+      chunks.push(this.encodeField(de, this.spec[de], fields[de]))
+    }
+
+    return { mti, bytes: Buffer.concat(chunks) }
+  }
+
+  unpack = (buf: Buffer): UnpackedMessage => {
+    let offset = 0
+    const { mti, read } = decodeMTI(buf, offset, this.mtiEncoding)
+    offset += read
+    assertMTI(mti)
+
+    if (buf.length - offset < 8) throw new Error(ERR.PRIMARY_UNDERRUN)
+    const primary = buf.subarray(offset, offset + 8)
+    offset += 8
+
+    const hasSecondary = (primary[0] & 0x80) !== 0
+    let bitmap = primary
+    if (hasSecondary) {
+      if (this.bitmapConstraint === 64) throw new Error(ERR.SEC_BITMAP_CONSTRAINED)
+      if (buf.length - offset < 8) throw new Error(ERR.SEC_UNDERRUN)
+      bitmap = Buffer.concat([primary, buf.subarray(offset, offset + 8)])
+      offset += 8
+    }
+
+    const present = parseBitmap(bitmap, this.bitmapConstraint)
+    const fields: Record<number, Buffer | string | number> = {}
+    for (const de of present) {
+      const spec = this.spec[de]
+      if (!spec) throw new Error(ERR.NO_SPEC(de))
+      const { value, read } = this.decodeField(de, spec, buf, offset)
+      fields[de] = value
+      offset += read
+    }
+
+    return { mti, fields, bytesRead: offset }
+  }
+
+  explain = (buf: Buffer): string => {
+    const decoded = this.unpack(buf)
+    const lines = [`MTI: ${decoded.mti}`]
+    for (const [idStr, value] of Object.entries(decoded.fields)) {
+      const id = Number(idStr)
+      const spec = this.spec[id]
+      const { kind, length } = spec.format
+      lines.push(`${id.toString().padStart(3, '0')} ${spec.name} (${kind}, len=${length}): ${value}`)
+    }
+    return lines.join('\n')
+  }
+
+  encodeField(de: number, spec: FieldSpec, value: Buffer | string | number): Buffer {
+    const f = spec.format
+    switch (f.kind) {
+      case Kind.Numeric:
+        return encodeNumeric(f, value as string | number)
+      case Kind.Alpha:
+      case Kind.AlphaNumeric:
+      case Kind.AlphaNumericSpecial:
+        return encodeAlpha(de, f, value as string)
+      case Kind.Binary:
+        return encodeBinary(de, f, value as Buffer | string)
+      case Kind.LLVAR:
+      case Kind.LLVARn:
+      case Kind.LLVARan:
+      case Kind.LLVARans:
+      case Kind.LLLVAR:
+      case Kind.LLLVARn:
+      case Kind.LLLVARan:
+      case Kind.LLLVARans:
+        return encodeVar(de, f, value as Buffer | string)
+      default:
+        throw new Error(ERR.UNSUPPORTED(f.kind))
+    }
+  }
+
+  decodeField(de: number, spec: FieldSpec, buf: Buffer, offset: number) {
+    const f = spec.format
+    switch (f.kind) {
+      case Kind.Numeric:
+        return decodeNumeric(f, buf, offset)
+      case Kind.Alpha:
+      case Kind.AlphaNumeric:
+      case Kind.AlphaNumericSpecial:
+        return decodeAlpha(f, buf, offset)
+      case Kind.Binary:
+        return decodeBinary(de, f, buf, offset)
+      case Kind.LLVAR:
+      case Kind.LLVARn:
+      case Kind.LLVARan:
+      case Kind.LLVARans:
+      case Kind.LLLVAR:
+      case Kind.LLLVARn:
+      case Kind.LLLVARan:
+      case Kind.LLLVARans:
+        return decodeVar(de, f, buf, offset)
+      default:
+        throw new Error(ERR.UNSUPPORTED(f.kind))
+    }
+  }
+}

--- a/tests/internals/formats.test.ts
+++ b/tests/internals/formats.test.ts
@@ -1,0 +1,163 @@
+import {
+  A,
+  AN,
+  ANS,
+  B,
+  bitmap,
+  Kind,
+  LLLVAR,
+  LLLVARan,
+  LLLVARans,
+  LLLVARn,
+  LLVAR,
+  LLVARan,
+  LLVARans,
+  LLVARn,
+  N,
+  NumericEncoding,
+} from '@internals/formats'
+import { validateLLLVar, validateLLVar } from '@internals/varlen'
+
+vi.mock('@internals/varlen', () => ({
+  validateLLVar: vi.fn(),
+  validateLLLVar: vi.fn(),
+}))
+
+describe('formats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('N', () => {
+    it('throws if length is 0', () => {
+      expect(() => N(0)).toThrow('N(): length must be > 0')
+    })
+    it('returns kind set to Numeric', () => {
+      expect(N(4, { encoding: NumericEncoding.BCD })).toStrictEqual({
+        kind: Kind.Numeric,
+        length: 4,
+        encoding: NumericEncoding.BCD,
+      })
+    })
+  })
+
+  describe('A', () => {
+    it('throws if length is 0', () => {
+      expect(() => A(0)).toThrow('A(): length must be > 0')
+    })
+    it('returns kind set to Alpha', () => {
+      expect(A(4)).toStrictEqual({
+        kind: Kind.Alpha,
+        length: 4,
+      })
+    })
+  })
+
+  describe('AN', () => {
+    it('throws if length is 0', () => {
+      expect(() => AN(0)).toThrow('AN(): length must be > 0')
+    })
+    it('returns kind set to AlphaNumeric', () => {
+      expect(AN(4)).toStrictEqual({
+        kind: Kind.AlphaNumeric,
+        length: 4,
+      })
+    })
+  })
+
+  describe('ANS', () => {
+    it('throws if length is 0', () => {
+      expect(() => ANS(0)).toThrow('ANS(): length must be > 0')
+    })
+    it('returns kind set to AlphaNumericSpecial', () => {
+      expect(ANS(4)).toStrictEqual({
+        kind: Kind.AlphaNumericSpecial,
+        length: 4,
+      })
+    })
+  })
+
+  describe('B', () => {
+    it('throws if length is 0', () => {
+      expect(() => B(0)).toThrow('B(): length must be > 0')
+    })
+    it('returns kind set to Binary', () => {
+      expect(B(4)).toStrictEqual({
+        kind: Kind.Binary,
+        length: 4,
+      })
+    })
+  })
+
+  describe('bitmap', () => {
+    it('throws if length is not 8 or 16', () => {
+      expect(() => bitmap(10 as any)).toThrow('bitmap(): length must be 8 or 16 bytes')
+    })
+    it('returns kind set to Bitmap', () => {
+      expect(bitmap(8)).toStrictEqual({
+        kind: Kind.Bitmap,
+        length: 8,
+      })
+    })
+  })
+
+  describe('VAR helpers', () => {
+    test.each([
+      { method: LLVAR, methodName: 'LLVAR', kind: Kind.LLVAR, expected: validateLLVar, expectedName: 'validateLLVar' },
+      {
+        method: LLVARn,
+        methodName: 'LLVARn',
+        kind: Kind.LLVARn,
+        expected: validateLLVar,
+        expectedName: 'validateLLVar',
+      },
+      {
+        method: LLVARan,
+        methodName: 'LLVARan',
+        kind: Kind.LLVARan,
+        expected: validateLLVar,
+        expectedName: 'validateLLVar',
+      },
+      {
+        method: LLVARans,
+        methodName: 'LLVARans',
+        kind: Kind.LLVARans,
+        expected: validateLLVar,
+        expectedName: 'validateLLVar',
+      },
+      { method: LLVAR, methodName: 'LLVAR', kind: Kind.LLVAR, expected: validateLLVar, expectedName: 'validateLLLVar' },
+      {
+        method: LLLVAR,
+        methodName: 'LLLVAR',
+        kind: Kind.LLLVAR,
+        expected: validateLLLVar,
+        expectedName: 'validateLLLVar',
+      },
+      {
+        method: LLLVARn,
+        methodName: 'LLLVARn',
+        kind: Kind.LLLVARn,
+        expected: validateLLLVar,
+        expectedName: 'validateLLLVar',
+      },
+      {
+        method: LLLVARan,
+        methodName: 'LLLVARan',
+        kind: Kind.LLLVARan,
+        expected: validateLLLVar,
+        expectedName: 'validateLLLVar',
+      },
+      {
+        method: LLLVARans,
+        methodName: 'LLLVARans',
+        kind: Kind.LLLVARans,
+        expected: validateLLLVar,
+        expectedName: 'validateLLLVar',
+      },
+    ] as const)('call $expectedName method with $kind for $methodName helper', ({ method, kind, expected }) => {
+      const validateMock = vi.mocked(expected)
+      method({ length: 4 })
+      expect(validateMock).toHaveBeenCalledWith(kind, { length: 4 })
+    })
+  })
+})

--- a/tests/internals/varlen.test.ts
+++ b/tests/internals/varlen.test.ts
@@ -7,7 +7,14 @@ import {
   VarLenHeaderEncoding,
   VarPayloadEncoding,
 } from '@internals/formats'
-import { applyVarDefaults, buildPayload, readLenHeader, writeLenHeader } from '@internals/varlen'
+import {
+  applyVarDefaults,
+  buildPayload,
+  readLenHeader,
+  validateLLLVar,
+  validateLLVar,
+  writeLenHeader,
+} from '@internals/varlen'
 import { toAsciiBuffer, toHex, toHexBuffer } from '../utils'
 
 vi.mock('@internals/bcd', () => ({
@@ -203,6 +210,40 @@ describe('varlen', () => {
         const resp = readLenHeader(toHexBuffer('02ABCDEF'), 0, 2, VarLenHeaderEncoding.BCD)
         expect(resp).to.deep.equal({ len: 2, read: 1 })
         expect(fromBcdMocked).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('validateLLVar', () => {
+    it('throws if length is 0', () => {
+      expect(() => validateLLVar(Kind.LLVARan, { length: 0 })).toThrow('LLVARan(): length must be > 0')
+    })
+
+    it('throws if length is > 99', () => {
+      expect(() => validateLLVar(Kind.LLVARan, { length: 110 })).toThrow('LLVARan(): length must be <= 99')
+    })
+
+    it('returns kind set to LLVARan', () => {
+      expect(validateLLVar(Kind.LLVARan, { length: 99 })).toStrictEqual({
+        kind: Kind.LLVARan,
+        length: 99,
+      })
+    })
+  })
+
+  describe('validateLLLVar', () => {
+    it('throws if length is 0', () => {
+      expect(() => validateLLLVar(Kind.LLLVARan, { length: 0 })).toThrow('LLLVARan(): length must be > 0')
+    })
+
+    it('throws if length is > 99', () => {
+      expect(() => validateLLLVar(Kind.LLLVARan, { length: 1100 })).toThrow('LLLVARan(): length must be <= 999')
+    })
+
+    it('returns kind set to LLLVARan', () => {
+      expect(validateLLLVar(Kind.LLLVARan, { length: 999 })).toStrictEqual({
+        kind: Kind.LLLVARan,
+        length: 999,
       })
     })
   })

--- a/tests/iso8583.test.ts
+++ b/tests/iso8583.test.ts
@@ -1,0 +1,337 @@
+import { buildBitmap, parseBitmap } from '@bits/bitmap'
+import { assertMTI, decodeMTI, encodeMTI } from '@bits/mti'
+import { decodeAlpha, encodeAlpha } from '@encodings/alpha'
+import { decodeBinary, encodeBinary } from '@encodings/binary'
+import { decodeNumeric, encodeNumeric } from '@encodings/numeric'
+import { decodeVar, encodeVar } from '@encodings/varlen'
+import { AN, B, bitmap, Iso8583, Kind, LLVARn, MessageSpec, N, NumericEncoding, VarLenHeaderEncoding } from '../src'
+import { toHexBuffer } from './utils'
+
+vi.mock('@bits/mti', () => ({
+  assertMTI: vi.fn(),
+  encodeMTI: vi.fn(),
+  decodeMTI: vi.fn(),
+}))
+
+vi.mock('@bits/bitmap', () => ({
+  buildBitmap: vi.fn(),
+  parseBitmap: vi.fn(),
+}))
+
+vi.mock('@encodings/alpha', () => ({
+  encodeAlpha: vi.fn(),
+  decodeAlpha: vi.fn(),
+}))
+
+vi.mock('@encodings/binary', () => ({
+  encodeBinary: vi.fn(),
+  decodeBinary: vi.fn(),
+}))
+
+vi.mock('@encodings/numeric', () => ({
+  encodeNumeric: vi.fn(),
+  decodeNumeric: vi.fn(),
+}))
+
+vi.mock('@encodings/varlen', () => ({
+  encodeVar: vi.fn(),
+  decodeVar: vi.fn(),
+}))
+
+describe('Iso8583', () => {
+  const messageSpec: MessageSpec = {
+    0: { name: 'MTI', format: N(4) },
+    1: { name: 'Bitmap', format: bitmap(8) },
+    2: {
+      name: 'PAN',
+      format: LLVARn({
+        length: 19,
+        lenHeader: VarLenHeaderEncoding.BCD,
+      }),
+    },
+    3: { name: 'ProcCode', format: N(6) },
+    22: { name: 'POSData', format: AN(12) },
+  }
+
+  const encodeMtiMock = vi.mocked(encodeMTI)
+  const decodeMtiMock = vi.mocked(decodeMTI)
+  const buildBitmmapMock = vi.mocked(buildBitmap)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(assertMTI).mockReturnThis()
+    encodeMtiMock.mockReturnValue(toHexBuffer('1200'))
+    decodeMtiMock.mockReturnValue({ mti: '1210', read: 4 })
+    buildBitmmapMock.mockReturnValue(toHexBuffer('6000000000000001'))
+  })
+
+  describe('main', () => {
+    it('throws if MTI kind is not numeric', () => {
+      expect(() => new Iso8583({ 0: { name: 'MTI', format: AN(4) } })).toThrow(
+        'Invalid MTI field DE0 spec (expect 4 digits, numeric)',
+      )
+    })
+
+    it('throws if bitmap kind is not binary', () => {
+      expect(() => new Iso8583({ ...messageSpec, 1: { name: 'bitmap', format: B(8) } })).toThrow(
+        'Invalid bitmap field DE1 spec (expect format: bitmap(8 or 16))',
+      )
+    })
+  })
+
+  describe('pack', () => {
+    it('throws if a field is present in passed data without a corresponding spec', () => {
+      const call = {
+        50: 'non-existing-spec',
+        22: '923456711300',
+      }
+      const iso8583 = new Iso8583(messageSpec)
+      expect(() => iso8583.pack('1200', call)).toThrow(/No spec for DE50/)
+    })
+
+    it('calls encodeMTI with (`1200`, `BCD`) default encoding', () => {
+      const call = {
+        22: '923456711300',
+      }
+      const iso8583 = new Iso8583(messageSpec)
+      const encodeFieldMock = vi.spyOn(iso8583, 'encodeField').mockReturnValue(toHexBuffer('1234'))
+      iso8583.pack('1200', call)
+      expect(encodeMtiMock).toHaveBeenCalledWith('1200', 'bcd')
+      expect(encodeFieldMock).toHaveBeenCalledWith(22, messageSpec[22], '923456711300')
+    })
+
+    it('calls encodeMTI with (`1200`, `ASCII`) when encoding is given encoding', () => {
+      const call = {
+        22: '923456711300',
+      }
+      const iso8583 = new Iso8583({
+        ...messageSpec,
+        0: { name: 'MTI', format: N(4, { encoding: NumericEncoding.ASCII }) },
+      })
+      const encodeFieldMock = vi.spyOn(iso8583, 'encodeField').mockReturnValue(toHexBuffer('1234'))
+      iso8583.pack('1200', call)
+      expect(encodeMtiMock).toHaveBeenCalledWith('1200', 'ascii')
+      expect(encodeFieldMock).toHaveBeenCalledWith(22, messageSpec[22], '923456711300')
+    })
+
+    it('calls buildBitmap with correct params with default bitmapConstraint of 64', () => {
+      const call = {
+        0: '1200',
+        3: '000000',
+        22: '923456711300',
+        130: 'invalid',
+      }
+      const iso8583 = new Iso8583(messageSpec)
+      const encodeFieldMock = vi.spyOn(iso8583, 'encodeField').mockReturnValue(toHexBuffer('1234'))
+      iso8583.pack('1200', call)
+      expect(buildBitmap).toHaveBeenCalledWith([3, 22], 64)
+      expect(encodeFieldMock).toHaveBeenCalled()
+    })
+
+    it('calls buildBitmap with correct params with given bitmapConstraint', () => {
+      const call = {
+        0: '1200',
+        3: '000000',
+        22: '923456711300',
+        130: 'invalid',
+      }
+      const iso8583 = new Iso8583({
+        ...messageSpec,
+        1: { name: 'Bitmap', format: bitmap(16) },
+      })
+      const encodeFieldMock = vi.spyOn(iso8583, 'encodeField').mockReturnValue(toHexBuffer('1234'))
+      iso8583.pack('1200', call)
+      expect(buildBitmap).toHaveBeenCalledWith([3, 22], 128)
+      expect(encodeFieldMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('unpack', () => {
+    it('throws if primary bitmap < 8', () => {
+      const iso8583 = new Iso8583(messageSpec)
+      expect(() => iso8583.unpack(toHexBuffer('12345678910'))).toThrow(/Primary bitmap underrun/)
+    })
+
+    it('throws if spec is constrained to 64, but secondary is present in the unpacking buffer', () => {
+      const iso8583 = new Iso8583(messageSpec)
+      const primary = Buffer.concat([Buffer.from([0x80]), Buffer.alloc(7, 0x00)])
+      const buf = Buffer.concat([Buffer.alloc(4), primary])
+      expect(() => iso8583.unpack(buf)).toThrow('Secondary bitmap present but constrained to 64')
+    })
+
+    it('throws secondary bitmap underrun when allowed but missing second 8 bytes', () => {
+      const iso8583 = new Iso8583({ ...messageSpec, 1: { name: 'Bitmap', format: bitmap(16) } })
+      const primary = Buffer.concat([Buffer.from([0x80]), Buffer.alloc(7, 0x00)])
+      const buf = Buffer.concat([Buffer.alloc(4), primary])
+      expect(() => iso8583.unpack(buf)).toThrow(/Secondary bitmap underrun/i)
+    })
+
+    it('parses primary only bitmap and returns fields and bytes read', () => {
+      const iso8583 = new Iso8583(messageSpec)
+      vi.mocked(parseBitmap).mockReturnValue([3])
+      const decodeFieldSpy = vi.spyOn(iso8583, 'decodeField').mockReturnValue({ value: 'V3', read: 6 })
+      const primary = toHexBuffer('0000000000000001')
+      const buf = Buffer.concat([Buffer.alloc(4), primary, Buffer.alloc(32)])
+      const out = iso8583.unpack(buf)
+      expect(decodeFieldSpy).toHaveBeenCalledWith(
+        3,
+        { name: 'ProcCode', format: { kind: Kind.Numeric, length: 6 } },
+        buf,
+        12,
+      )
+      expect(out).toEqual({ mti: '1210', fields: { 3: 'V3' }, bytesRead: 18 })
+    })
+
+    it('parses with secondary bitmap when 128-bit is allowed', () => {
+      const iso8583 = new Iso8583({ ...messageSpec, 1: { name: 'Bitmap', format: bitmap(16) } })
+      vi.mocked(parseBitmap).mockReturnValue([3])
+      vi.spyOn(iso8583, 'decodeField').mockReturnValue({ value: 'V3', read: 6 })
+
+      const primary = Buffer.concat([Buffer.from([0x80]), Buffer.alloc(7, 0x00)])
+      const secondary = Buffer.alloc(8, 0x00)
+
+      const buf = Buffer.concat([Buffer.alloc(4), primary, secondary, Buffer.alloc(64)])
+      const out = iso8583.unpack(buf)
+
+      expect(out).toEqual({ mti: '1210', fields: { 3: 'V3' }, bytesRead: 26 })
+    })
+
+    it('throws if a present DE has no spec', () => {
+      const iso8583 = new Iso8583(messageSpec)
+      vi.mocked(parseBitmap).mockReturnValue([3, 50])
+      vi.spyOn(iso8583, 'decodeField').mockReturnValue({ value: 'V3', read: 6 })
+      const primary = toHexBuffer('0000000000000001')
+      const buf = Buffer.concat([Buffer.alloc(4), primary, Buffer.alloc(16)])
+
+      expect(() => iso8583.unpack(buf)).toThrow(/No spec for DE50/)
+    })
+  })
+
+  describe('explain', () => {
+    it('returns string converted to readable format', () => {
+      const iso8583 = new Iso8583(messageSpec)
+      vi.spyOn(iso8583, 'unpack').mockReturnValue({
+        mti: '1210',
+        bytesRead: 20,
+        fields: { 3: '000000', 22: '923456711300' },
+      })
+      const explainResp = iso8583.explain(Buffer.from([0x12]))
+      expect(explainResp).toStrictEqual(
+        'MTI: 1210\n003 ProcCode (n, len=6): 000000\n022 POSData (an, len=12): 923456711300',
+      )
+    })
+  })
+
+  describe('encodeField', () => {
+    const encodeNumericMock = vi.mocked(encodeNumeric)
+    const encodeAlphaMock = vi.mocked(encodeAlpha)
+    const encodeBinaryMock = vi.mocked(encodeBinary)
+    const encodeVarMock = vi.mocked(encodeVar)
+    const iso8583 = new Iso8583({})
+
+    it('calls encodeNumeric for Numeric field in number format', () => {
+      iso8583.encodeField(1, { name: 'NumericField', format: { kind: Kind.Numeric, length: 4 } }, 123456)
+      expect(encodeNumericMock).toHaveBeenCalledWith({ kind: Kind.Numeric, length: 4 }, 123456)
+    })
+
+    it('calls encodeNumeric for Numeric field in string format', () => {
+      iso8583.encodeField(1, { name: 'NumericField', format: { kind: Kind.Numeric, length: 4 } }, '123456')
+      expect(encodeNumericMock).toHaveBeenCalledWith({ kind: Kind.Numeric, length: 4 }, '123456')
+    })
+
+    test.each([
+      [Kind.Alpha, 'Alpha'],
+      [Kind.AlphaNumeric, 'AlphaNumeric'],
+      [Kind.AlphaNumericSpecial, 'AlphaNumericSpecial'],
+    ] as const)('call encodeAlpha for $1', (kind, name) => {
+      iso8583.encodeField(1, { name, format: { kind, length: 4 } }, 'some-value')
+      expect(encodeAlphaMock).toHaveBeenCalledWith(1, { kind, length: 4 }, 'some-value')
+    })
+
+    it('calls encodeBinary for Binary field', () => {
+      iso8583.encodeField(1, { name: 'BinaryField', format: { kind: Kind.Binary, length: 4 } }, Buffer.from([0x01]))
+      expect(encodeBinaryMock).toHaveBeenCalledWith(1, { kind: Kind.Binary, length: 4 }, Buffer.from([0x01]))
+    })
+
+    test.each([
+      [Kind.LLVAR, 'LLVAR'],
+      [Kind.LLVARn, 'LLVARn'],
+      [Kind.LLVARan, 'LLVARan'],
+      [Kind.LLVARans, 'LLVARans'],
+      [Kind.LLLVAR, 'LLLVAR'],
+      [Kind.LLLVARn, 'LLLVARn'],
+      [Kind.LLLVARan, 'LLLVARan'],
+      [Kind.LLLVARans, 'LLLVARans'],
+    ] as const)('call encodeVar for $1', (kind, name) => {
+      iso8583.encodeField(1, { name, format: { kind, length: 4 } }, Buffer.from([0x01]))
+      expect(encodeVarMock).toHaveBeenCalledWith(1, { kind, length: 4 }, Buffer.from([0x01]))
+    })
+
+    it('throws if kind is unsupported', () => {
+      expect(() =>
+        iso8583.encodeField(
+          1,
+          { name: 'UnsupportedKind', format: { kind: 'Unsupported', length: 4 } as any },
+          Buffer.from([0x01]),
+        ),
+      ).toThrow(/Unsupported format Unsupported/)
+    })
+  })
+
+  describe('decodeField', () => {
+    const decodeNumericMock = vi.mocked(decodeNumeric)
+    const decodeAlphaMock = vi.mocked(decodeAlpha)
+    const decodeBinaryMock = vi.mocked(decodeBinary)
+    const decodeVarMock = vi.mocked(decodeVar)
+    const iso8583 = new Iso8583({})
+
+    it('calls decodeNumeric for Numeric field', () => {
+      iso8583.decodeField(
+        1,
+        { name: 'NumericField', format: { kind: Kind.Numeric, length: 4 } },
+        Buffer.from([0x01]),
+        0,
+      )
+      expect(decodeNumericMock).toHaveBeenCalledWith({ kind: Kind.Numeric, length: 4 }, Buffer.from([0x01]), 0)
+    })
+
+    test.each([
+      [Kind.Alpha, 'Alpha'],
+      [Kind.AlphaNumeric, 'AlphaNumeric'],
+      [Kind.AlphaNumericSpecial, 'AlphaNumericSpecial'],
+    ] as const)('call decodeAlpha for $1', (kind, name) => {
+      iso8583.decodeField(1, { name, format: { kind, length: 4 } }, Buffer.from([0x01]), 0)
+      expect(decodeAlphaMock).toHaveBeenCalledWith({ kind, length: 4 }, Buffer.from([0x01]), 0)
+    })
+
+    it('calls decodeBinary for Binary field', () => {
+      iso8583.decodeField(1, { name: 'BinaryField', format: { kind: Kind.Binary, length: 4 } }, Buffer.from([0x01]), 0)
+      expect(decodeBinaryMock).toHaveBeenCalledWith(1, { kind: Kind.Binary, length: 4 }, Buffer.from([0x01]), 0)
+    })
+
+    test.each([
+      [Kind.LLVAR, 'LLVAR'],
+      [Kind.LLVARn, 'LLVARn'],
+      [Kind.LLVARan, 'LLVARan'],
+      [Kind.LLVARans, 'LLVARans'],
+      [Kind.LLLVAR, 'LLLVAR'],
+      [Kind.LLLVARn, 'LLLVARn'],
+      [Kind.LLLVARan, 'LLLVARan'],
+      [Kind.LLLVARans, 'LLLVARans'],
+    ] as const)('call decodeVar for $1', (kind, name) => {
+      iso8583.decodeField(1, { name, format: { kind, length: 4 } }, Buffer.from([0x01]), 0)
+      expect(decodeVarMock).toHaveBeenCalledWith(1, { kind, length: 4 }, Buffer.from([0x01]), 0)
+    })
+
+    it('throws if kind is unsupported', () => {
+      expect(() =>
+        iso8583.decodeField(
+          1,
+          { name: 'UnsupportedKind', format: { kind: 'Unsupported', length: 4 } as any },
+          Buffer.from([0x01]),
+          0,
+        ),
+      ).toThrow(/Unsupported format Unsupported/)
+    })
+  })
+})

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
+    "stripInternal": true,
     "sourceMap": true,
     "removeComments": false,
     "noImplicitAny": true,


### PR DESCRIPTION
Last bit of the code before getting into configuration and pushing to NPM.
Below is how consumers can define their message specification:

```
export const elavonSpec: MessageSpec = {
  0: { name: 'MTI', format: N(4) },
  1: { name: 'Bitmap', format: bitmap(8) },
  2: {
    name: 'PAN',
    format: LLVARn({
      length: 19,
      lenHeader: VarLenHeaderEncoding.BCD,
      payload: VarPayloadEncoding.BCD_DIGITS,
      lenCountMode: VarLenCountMode.DIGITS,
    }),
  },
  22: { name: 'POSData', format: AN(12) },
  35: { name: 'Track2', format: LLVARans({ length: 37 }) },
  38: { name: 'ApprovalCode', format: ANS(6) },
  43: { name: 'PaymentFacilitator', format: LLVARan({ length: 99 }) },
  48: { name: 'PrivateData', format: LLLVAR({ length: 999, payload: VarPayloadEncoding.BINARY }) },
  54: { name: 'AmountOther', format: LLLVARans({ length: 120 }) },
  55: { name: 'EMV', format: LLLVAR({ length: 999, payload: VarPayloadEncoding.BINARY }) },
  64: { name: 'MAC', format: B(8) },
}```